### PR TITLE
Remove unused Git attributes ident

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,4 +1,3 @@
-dnl $Id$
 dnl config.m4 for extension ibm_db2
 
 dnl Comments in this file start with the string 'dnl'.

--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -19,8 +19,6 @@
   |          Tony Cairns, Krishna Raman, Ambrish Bhargava,               |
   |          Rahul Priyadarshi, Praveen Devarao,                         |
   +----------------------------------------------------------------------+
-
-  $Id$
 */
 
 #ifdef HAVE_CONFIG_H

--- a/php_ibm_db2.h
+++ b/php_ibm_db2.h
@@ -19,8 +19,6 @@
   |          Dan Scott, Helmut Tessarek, Ambrish Bhargava,               |
   |          Rahul Priyadarshi                                           |
   +----------------------------------------------------------------------+
-
-  $Id$
 */
 
 #define	PHP_IBM_DB2_VERSION	"2.0.4"


### PR DESCRIPTION
Hello,

The `$Id$` keywords were used in Subversion where they can be substituted with filename, last revision number change, last changed date, and last user who changed it.

In Git this functionality is different and can be done with Git attribute ident. These need to be defined manually for each file in the .gitattributes file and are afterwards replaced with 40-character
hexadecimal blob object name which is based only on the particular file contents.

This patch simplifies handling of $Id$ keywords by removing them since they are not used anymore.

Thanks.