### PR TITLE
Fix warnings about int to pointer conversions when sizes don't match

### DIFF
--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -1376,7 +1376,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
                                 vParam = SQL_CURSOR_KEYSET_DRIVEN;
                                 ((stmt_handle *)handle)->cursor_type = DB2_SCROLLABLE;
                                 rc = SQLSetStmtAttr((SQLHSTMT)((stmt_handle *)handle)->hstmt,
-                                    SQL_ATTR_CURSOR_TYPE, (SQLPOINTER)vParam,
+                                    SQL_ATTR_CURSOR_TYPE, (SQLPOINTER)(intptr_t)vParam,
                                     SQL_IS_INTEGER );
                                 if ( rc == SQL_ERROR ) {
                                     _php_db2_check_sql_errors((SQLHSTMT)((stmt_handle *)handle)->hstmt, SQL_HANDLE_STMT, rc, 1, NULL, -1, 1 TSRMLS_CC);
@@ -1385,7 +1385,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
                                 vParam = DB2_SCROLLABLE;
                                 ((stmt_handle *)handle)->cursor_type = DB2_SCROLLABLE;
                                 rc = SQLSetStmtAttr((SQLHSTMT)((stmt_handle *)handle)->hstmt,
-                                    SQL_ATTR_CURSOR_TYPE, (SQLPOINTER)vParam, /* was (SQLPOINTER)&vParam */
+                                    SQL_ATTR_CURSOR_TYPE, (SQLPOINTER)(intptr_t)vParam, /* was (SQLPOINTER)&vParam */
                                     SQL_IS_INTEGER );
                                 if ( rc == SQL_ERROR ) {
                                     _php_db2_check_sql_errors((SQLHSTMT)((stmt_handle *)handle)->hstmt, SQL_HANDLE_STMT, rc, 1, NULL, -1, 1 TSRMLS_CC);
@@ -1397,7 +1397,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
                             if (is_ios != 1) {      /* Not i5 */
                                 vParam = SQL_SCROLL_FORWARD_ONLY;
                                 rc = SQLSetStmtAttr((SQLHSTMT)((stmt_handle *)handle)->hstmt,
-                                    SQL_ATTR_CURSOR_TYPE, (SQLPOINTER)vParam,
+                                    SQL_ATTR_CURSOR_TYPE, (SQLPOINTER)(intptr_t)vParam,
                                     SQL_IS_INTEGER );
                                 if ( rc == SQL_ERROR ) {
                                     _php_db2_check_sql_errors((SQLHSTMT)((stmt_handle *)handle)->hstmt, SQL_HANDLE_STMT, rc, 1, NULL, -1, 1 TSRMLS_CC);
@@ -1405,7 +1405,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
                             } else {                /* Is i5 */
                                 vParam = DB2_FORWARD_ONLY;
                                 rc = SQLSetStmtAttr((SQLHSTMT)((stmt_handle *)handle)->hstmt,
-                                    SQL_ATTR_CURSOR_TYPE, (SQLPOINTER)vParam, /* was (SQLPOINTER)&vParam */
+                                    SQL_ATTR_CURSOR_TYPE, (SQLPOINTER)(intptr_t)vParam, /* was (SQLPOINTER)&vParam */
                                     SQL_IS_INTEGER );
                                 if ( rc == SQL_ERROR ) {
                                     _php_db2_check_sql_errors((SQLHSTMT)((stmt_handle *)handle)->hstmt, SQL_HANDLE_STMT, rc, 1, NULL, -1, 1 TSRMLS_CC);
@@ -1434,7 +1434,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
                             vParam = DB2_ROWCOUNT_PREFETCH_ON;
                             ((stmt_handle *)handle)->s_rowcount = DB2_ROWCOUNT_PREFETCH_ON;
                             rc = SQLSetStmtAttr((SQLHSTMT)((stmt_handle *)handle)->hstmt,
-                                SQL_ATTR_ROWCOUNT_PREFETCH, (SQLPOINTER)vParam,
+                                SQL_ATTR_ROWCOUNT_PREFETCH, (SQLPOINTER)(intptr_t)vParam,
                                 SQL_IS_INTEGER );
                             if ( rc == SQL_ERROR ) {
                                 _php_db2_check_sql_errors((SQLHSTMT)((stmt_handle *)handle)->hstmt, SQL_HANDLE_STMT, rc, 1, NULL, -1, 1 TSRMLS_CC);
@@ -1443,7 +1443,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
                             vParam = DB2_ROWCOUNT_PREFETCH_ON;
                             ((stmt_handle *)handle)->s_rowcount = DB2_ROWCOUNT_PREFETCH_ON;
                             rc = SQLSetStmtAttr((SQLHSTMT)((stmt_handle *)handle)->hstmt,
-                                SQL_ATTR_ROWCOUNT_PREFETCH, (SQLPOINTER)vParam, /* was (SQLPOINTER)&vParam */
+                                SQL_ATTR_ROWCOUNT_PREFETCH, (SQLPOINTER)(intptr_t)vParam, /* was (SQLPOINTER)&vParam */
                                 SQL_IS_INTEGER );
                             if ( rc == SQL_ERROR ) {
                                 _php_db2_check_sql_errors((SQLHSTMT)((stmt_handle *)handle)->hstmt, SQL_HANDLE_STMT, rc, 1, NULL, -1, 1 TSRMLS_CC);
@@ -1455,7 +1455,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
                         if (is_ios != 1) {      /* Not i5 */
                             vParam = DB2_ROWCOUNT_PREFETCH_OFF;
                             rc = SQLSetStmtAttr((SQLHSTMT)((stmt_handle *)handle)->hstmt,
-                                SQL_ATTR_ROWCOUNT_PREFETCH, (SQLPOINTER)vParam,
+                                SQL_ATTR_ROWCOUNT_PREFETCH, (SQLPOINTER)(intptr_t)vParam,
                                 SQL_IS_INTEGER );
                             if ( rc == SQL_ERROR ) {
                                 _php_db2_check_sql_errors((SQLHSTMT)((stmt_handle *)handle)->hstmt, SQL_HANDLE_STMT, rc, 1, NULL, -1, 1 TSRMLS_CC);
@@ -1463,7 +1463,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
                         } else {                /* Is i5 */
                             vParam = DB2_ROWCOUNT_PREFETCH_OFF;
                             rc = SQLSetStmtAttr((SQLHSTMT)((stmt_handle *)handle)->hstmt,
-                                SQL_ATTR_ROWCOUNT_PREFETCH, (SQLPOINTER)vParam, /* was (SQLPOINTER)&vParam */
+                                SQL_ATTR_ROWCOUNT_PREFETCH, (SQLPOINTER)(intptr_t)vParam, /* was (SQLPOINTER)&vParam */
                                 SQL_IS_INTEGER );
                             if ( rc == SQL_ERROR ) {
                                 _php_db2_check_sql_errors((SQLHSTMT)((stmt_handle *)handle)->hstmt, SQL_HANDLE_STMT, rc, 1, NULL, -1, 1 TSRMLS_CC);
@@ -1488,7 +1488,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
                         rc = SQLSetConnectAttr(
                                 (SQLHDBC)((conn_handle*)handle)->hdbc, 
                                 SQL_ATTR_USE_TRUSTED_CONTEXT, 
-                                (SQLPOINTER)SQL_TRUE, SQL_IS_INTEGER);
+                                (SQLPOINTER)(intptr_t)SQL_TRUE, SQL_IS_INTEGER);
 
                         if ( rc == SQL_ERROR ) {
                             _php_db2_check_sql_errors((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_HANDLE_DBC, rc, 1, NULL, -1, 1 TSRMLS_CC);
@@ -1557,7 +1557,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
         }
     } else if (!STRCASECMP(opt_key, "query_timeout")) {
         if (type == SQL_HANDLE_STMT) {
-            rc = SQLSetStmtAttr((SQLHSTMT)((stmt_handle*)handle)->hstmt, SQL_ATTR_QUERY_TIMEOUT, (SQLPOINTER) option_num, SQL_IS_UINTEGER );
+            rc = SQLSetStmtAttr((SQLHSTMT)((stmt_handle*)handle)->hstmt, SQL_ATTR_QUERY_TIMEOUT, (SQLPOINTER)(uintptr_t)option_num, SQL_IS_UINTEGER );
             if ( rc == SQL_ERROR ) {
                 _php_db2_check_sql_errors((SQLHSTMT)((stmt_handle*)handle)->hstmt, SQL_HANDLE_STMT, rc, 1, NULL, -1, 1 TSRMLS_CC);
             }
@@ -1572,7 +1572,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
                      * with this option.
                      */
                     pvParam = SQL_AUTOCOMMIT_ON;
-                    rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)pvParam, SQL_IS_INTEGER);
+                    rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)(intptr_t)pvParam, SQL_IS_INTEGER);
                     if ( rc == SQL_ERROR ) {
                         _php_db2_check_sql_errors((SQLHSTMT)((conn_handle*)handle)->hdbc, SQL_HANDLE_DBC, rc, 1, NULL, -1, 1 TSRMLS_CC);
                     } else {
@@ -1584,7 +1584,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
 
                 case DB2_AUTOCOMMIT_OFF:
                     pvParam = SQL_AUTOCOMMIT_OFF;
-                    rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)pvParam, SQL_IS_INTEGER);
+                    rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)(intptr_t)pvParam, SQL_IS_INTEGER);
                     if ( rc == SQL_ERROR ) {
                         _php_db2_check_sql_errors((SQLHSTMT)((conn_handle*)handle)->hdbc, SQL_HANDLE_DBC, rc, 1, NULL, -1, 1 TSRMLS_CC);
                     } else {
@@ -1698,7 +1698,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
             case DB2_I5_TXN_REPEATABLE_READ:
             case DB2_I5_TXN_SERIALIZABLE:
             case DB2_I5_TXN_NO_COMMIT:
-                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_TXN_ISOLATION, (SQLPOINTER)pvParam, SQL_IS_INTEGER);
+                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_TXN_ISOLATION, (SQLPOINTER)(intptr_t)pvParam, SQL_IS_INTEGER);
                 if ( rc == SQL_ERROR ) {
                     _php_db2_check_sql_errors((SQLHSTMT)((conn_handle*)handle)->hdbc, SQL_HANDLE_DBC, rc, 1, NULL, -1, 1 TSRMLS_CC);
                 }
@@ -1722,7 +1722,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
             case DB2_I5_NAMING_ON:
             case DB2_I5_NAMING_OFF:
                 ((conn_handle*)handle)->c_i5_sys_naming = option_num;
-                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_DBC_SYS_NAMING, (SQLPOINTER)pvParam, SQL_IS_INTEGER);
+                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_DBC_SYS_NAMING, (SQLPOINTER)(intptr_t)pvParam, SQL_IS_INTEGER);
                 if ( rc == SQL_ERROR ) {
                     _php_db2_check_sql_errors((SQLHSTMT)((conn_handle*)handle)->hdbc, SQL_HANDLE_DBC, rc, 1, NULL, -1, 1 TSRMLS_CC);
                 }
@@ -1796,7 +1796,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
             case DB2_I5_FMT_YMD:
             case DB2_I5_FMT_JUL:
             case DB2_I5_FMT_JOB:
-                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_DATE_FMT, (SQLPOINTER)pvParam, SQL_IS_INTEGER);
+                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_DATE_FMT, (SQLPOINTER)(intptr_t)pvParam, SQL_IS_INTEGER);
                 if ( rc == SQL_ERROR ) {
                     _php_db2_check_sql_errors((SQLHSTMT)((conn_handle*)handle)->hdbc, SQL_HANDLE_DBC, rc, 1, NULL, -1, 1 TSRMLS_CC);
                 }
@@ -1821,7 +1821,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
             case DB2_I5_SEP_COMMA:
             case DB2_I5_SEP_BLANK:
             case DB2_I5_SEP_JOB:
-                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_DATE_SEP, (SQLPOINTER)pvParam, SQL_IS_INTEGER);
+                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_DATE_SEP, (SQLPOINTER)(intptr_t)pvParam, SQL_IS_INTEGER);
                 if ( rc == SQL_ERROR ) {
                     _php_db2_check_sql_errors((SQLHSTMT)((conn_handle*)handle)->hdbc, SQL_HANDLE_DBC, rc, 1, NULL, -1, 1 TSRMLS_CC);
                 }
@@ -1844,7 +1844,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
             case DB2_I5_FMT_EUR:
             case DB2_I5_FMT_JIS:
             case DB2_I5_FMT_HMS:
-                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_TIME_FMT, (SQLPOINTER)pvParam, SQL_IS_INTEGER);
+                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_TIME_FMT, (SQLPOINTER)(intptr_t)pvParam, SQL_IS_INTEGER);
                 if ( rc == SQL_ERROR ) {
                     _php_db2_check_sql_errors((SQLHSTMT)((conn_handle*)handle)->hdbc, SQL_HANDLE_DBC, rc, 1, NULL, -1, 1 TSRMLS_CC);
                 }
@@ -1867,7 +1867,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
             case DB2_I5_SEP_COMMA:
             case DB2_I5_SEP_BLANK:
             case DB2_I5_SEP_JOB:
-                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_TIME_SEP, (SQLPOINTER)pvParam, SQL_IS_INTEGER);
+                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_TIME_SEP, (SQLPOINTER)(intptr_t)pvParam, SQL_IS_INTEGER);
                 if ( rc == SQL_ERROR ) {
                     _php_db2_check_sql_errors((SQLHSTMT)((conn_handle*)handle)->hdbc, SQL_HANDLE_DBC, rc, 1, NULL, -1, 1 TSRMLS_CC);
                 }
@@ -1886,7 +1886,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
             case DB2_I5_SEP_PERIOD:
             case DB2_I5_SEP_COMMA:
             case DB2_I5_SEP_JOB:
-                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_DECIMAL_SEP, (SQLPOINTER)pvParam, SQL_IS_INTEGER);
+                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_DECIMAL_SEP, (SQLPOINTER)(intptr_t)pvParam, SQL_IS_INTEGER);
                 if ( rc == SQL_ERROR ) {
                     _php_db2_check_sql_errors((SQLHSTMT)((conn_handle*)handle)->hdbc, SQL_HANDLE_DBC, rc, 1, NULL, -1, 1 TSRMLS_CC);
                 }
@@ -1916,7 +1916,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
          * DB2_I5_JOB_SORT_OFF value turns off DB2 UDB CLI job sortmode. 
          */
         pvParam = option_num;
-        rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_CONN_SORT_SEQUENCE, (SQLPOINTER)pvParam, SQL_IS_INTEGER);
+        rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_CONN_SORT_SEQUENCE, (SQLPOINTER)(intptr_t)pvParam, SQL_IS_INTEGER);
         if ( rc == SQL_ERROR ) {
             _php_db2_check_sql_errors((SQLHSTMT)((conn_handle*)handle)->hdbc, SQL_HANDLE_DBC, rc, 1, NULL, -1, 1 TSRMLS_CC);
         }
@@ -1952,7 +1952,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
         switch (option_num) {
             case DB2_FIRST_IO:
             case DB2_ALL_IO:
-                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_QUERY_OPTIMIZE_GOAL, (SQLPOINTER)pvParam, SQL_IS_INTEGER);
+                rc = SQLSetConnectAttr((SQLHDBC)((conn_handle*)handle)->hdbc, SQL_ATTR_QUERY_OPTIMIZE_GOAL, (SQLPOINTER)(intptr_t)pvParam, SQL_IS_INTEGER);
                 if ( rc == SQL_ERROR ) {
                     _php_db2_check_sql_errors((SQLHSTMT)((conn_handle*)handle)->hdbc, SQL_HANDLE_DBC, rc, 1, NULL, -1, 1 TSRMLS_CC);
                 }
@@ -1971,7 +1971,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
             case DB2_I5_FETCH_ON:
             case DB2_I5_FETCH_OFF:
                 rc = SQLSetStmtAttr((SQLHSTMT)((stmt_handle *)handle)->hstmt,
-                    SQL_ATTR_FOR_FETCH_ONLY, (SQLPOINTER)pvParam,
+                    SQL_ATTR_FOR_FETCH_ONLY, (SQLPOINTER)(intptr_t)pvParam,
                     SQL_IS_INTEGER );
                 if ( rc == SQL_ERROR ) {
                     _php_db2_check_sql_errors((SQLHSTMT)((stmt_handle *)handle)->hstmt, SQL_HANDLE_STMT, rc, 1, NULL, -1, 1 TSRMLS_CC);
@@ -2012,7 +2012,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
             case DB2_DEFERRED_PREPARE_ON:
                 pvParam = SQL_DEFERRED_PREPARE_ON;
                 rc = SQLSetStmtAttr((SQLHSTMT)((stmt_handle *)handle)->hstmt,
-                        SQL_ATTR_DEFERRED_PREPARE, (SQLPOINTER)pvParam,
+                        SQL_ATTR_DEFERRED_PREPARE, (SQLPOINTER)(intptr_t)pvParam,
                         SQL_IS_INTEGER );
                 if ( rc == SQL_ERROR ) {
                     _php_db2_check_sql_errors((SQLHSTMT)((stmt_handle *)handle)->hstmt, SQL_HANDLE_STMT, rc, 1, NULL, -1, 1 TSRMLS_CC);
@@ -2022,7 +2022,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
             case DB2_DEFERRED_PREPARE_OFF:
                 pvParam = SQL_DEFERRED_PREPARE_OFF;
                 rc = SQLSetStmtAttr((SQLHSTMT)((stmt_handle *)handle)->hstmt,
-                        SQL_ATTR_DEFERRED_PREPARE, (SQLPOINTER)pvParam,
+                        SQL_ATTR_DEFERRED_PREPARE, (SQLPOINTER)(intptr_t)pvParam,
                         SQL_IS_INTEGER );
                 if ( rc == SQL_ERROR ) {
                     _php_db2_check_sql_errors((SQLHSTMT)((stmt_handle *)handle)->hstmt, SQL_HANDLE_STMT, rc, 1, NULL, -1, 1 TSRMLS_CC);
@@ -2677,12 +2677,12 @@ static int _php_db2_connect_helper( INTERNAL_FUNCTION_PARAMETERS, conn_handle **
                 break;
             }
 #ifndef PASE /* IBM i not support SQL_ATTR_ODBC_VERSION */
-            rc = SQLSetEnvAttr((SQLHENV)conn_res->henv, SQL_ATTR_ODBC_VERSION, (void *)SQL_OV_ODBC3, SQL_IS_INTEGER);
+            rc = SQLSetEnvAttr((SQLHENV)conn_res->henv, SQL_ATTR_ODBC_VERSION, (SQLPOINTER)(intptr_t)SQL_OV_ODBC3, SQL_IS_INTEGER);
 #else /* IBM i enter server mode early (connect QSQSRVR jobs) */
             /* orig  - IBM i enter server mode early (connect QSQSRVR jobs) */
             if (IBM_DB2_G(i5_ignore_userid) < 1 && !is_i5_server_mode) {
                 attr = SQL_TRUE;
-                rc = SQLSetEnvAttr((SQLHENV)conn_res->henv, SQL_ATTR_SERVER_MODE, (SQLPOINTER)attr, SQL_IS_INTEGER);
+                rc = SQLSetEnvAttr((SQLHENV)conn_res->henv, SQL_ATTR_SERVER_MODE, (SQLPOINTER)(intptr_t)attr, SQL_IS_INTEGER);
                 if (rc == SQL_SUCCESS) {
                     is_i5_server_mode=1;
                 }
@@ -2690,7 +2690,7 @@ static int _php_db2_connect_helper( INTERNAL_FUNCTION_PARAMETERS, conn_handle **
             /* 1.9.7 - IBM i lobs come back +1 (bug) */
             if (!is_i5_null_in_len) {
                 attr = SQL_FALSE;
-                rc = SQLSetEnvAttr((SQLHENV)conn_res->henv, SQL_ATTR_INCLUDE_NULL_IN_LEN, (SQLPOINTER)attr, SQL_IS_INTEGER);
+                rc = SQLSetEnvAttr((SQLHENV)conn_res->henv, SQL_ATTR_INCLUDE_NULL_IN_LEN, (SQLPOINTER)(intptr_t)attr, SQL_IS_INTEGER);
                 if (rc == SQL_SUCCESS) {
                     is_i5_null_in_len=1;
                 }
@@ -2698,7 +2698,7 @@ static int _php_db2_connect_helper( INTERNAL_FUNCTION_PARAMETERS, conn_handle **
             /* 1.9.7 - IBM i 1208 data */
             if (is_i5_override_ccsid == 1 && IBM_DB2_G(i5_override_ccsid) == 1208) {
                 attr = SQL_TRUE;
-                rc = SQLSetEnvAttr((SQLHENV)conn_res->henv, SQL_ATTR_UTF8, (SQLPOINTER)attr, SQL_IS_INTEGER);
+                rc = SQLSetEnvAttr((SQLHENV)conn_res->henv, SQL_ATTR_UTF8, (SQLPOINTER)(intptr_t)attr, SQL_IS_INTEGER);
                 if (rc == SQL_SUCCESS) {
                     is_i5_override_ccsid=2;
                 }
@@ -2743,22 +2743,22 @@ static int _php_db2_connect_helper( INTERNAL_FUNCTION_PARAMETERS, conn_handle **
             else if (IBM_DB2_G(i5_allow_commit) >= 2) attr = SQL_TXN_READ_COMMITTED;
             else if (IBM_DB2_G(i5_allow_commit) >= 1) attr = SQL_TXN_READ_UNCOMMITTED;
             else attr = SQL_TXN_NO_COMMIT;
-            rc = SQLSetConnectAttr((SQLHDBC)conn_res->hdbc, SQL_ATTR_TXN_ISOLATION, (SQLPOINTER)attr, SQL_IS_INTEGER);
+            rc = SQLSetConnectAttr((SQLHDBC)conn_res->hdbc, SQL_ATTR_TXN_ISOLATION, (SQLPOINTER)(intptr_t)attr, SQL_IS_INTEGER);
         }
         /* 1.9.7 - IBM i + LUW 10.5 system naming on (*libl)/file.mbr */
         conn_res->c_i5_sys_naming = IBM_DB2_G(i5_sys_naming);
         conn_res->c_i5_pending_chglibl = NULL;
         conn_res->c_i5_pending_chgcurlib = NULL;
         if (conn_res->c_i5_sys_naming > 0) {
-            rc = SQLSetConnectAttr((SQLHDBC)conn_res->hdbc, SQL_ATTR_DBC_SYS_NAMING, (SQLPOINTER)SQL_TRUE, SQL_IS_INTEGER);
+            rc = SQLSetConnectAttr((SQLHDBC)conn_res->hdbc, SQL_ATTR_DBC_SYS_NAMING, (SQLPOINTER)(intptr_t)SQL_TRUE, SQL_IS_INTEGER);
         }
         /* 1.9.7 - default autocommit=on before _php_db2_parse_options (comment add only) */ 
-        rc = SQLSetConnectAttr((SQLHDBC)conn_res->hdbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)(conn_res->auto_commit), SQL_IS_INTEGER);
+        rc = SQLSetConnectAttr((SQLHDBC)conn_res->hdbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)(intptr_t)(conn_res->auto_commit), SQL_IS_INTEGER);
 #ifdef PASE /* 1.9.7 - IBM i  moved before _php_db2_parse_options (bug) */
         /* orig  - IBM i SQL_ATTR_JOB_SORT_SEQUENCE (customer request DB2 PTF) */
         if (IBM_DB2_G(i5_job_sort) > 0) {
             attr = SQL_JOBRUN_SORT_SEQUENCE;
-            rc = SQLSetConnectAttr((SQLHDBC)conn_res->hdbc, SQL_ATTR_CONN_SORT_SEQUENCE, (SQLPOINTER)attr, SQL_IS_INTEGER);
+            rc = SQLSetConnectAttr((SQLHDBC)conn_res->hdbc, SQL_ATTR_CONN_SORT_SEQUENCE, (SQLPOINTER)(intptr_t)attr, SQL_IS_INTEGER);
         }
         /* 1.9.7 - IBM i consultant request switch subsystem QSQSRVR job (customer workload issues) */
         if (IBM_DB2_G(i5_servermode_subsystem) && strlen(IBM_DB2_G(i5_servermode_subsystem)) > 0 && IBM_DB2_G(i5_ignore_userid) < 1) {
@@ -2978,7 +2978,7 @@ static void _php_db2_set_decfloat_rounding_mode_client(void* handle TSRMLS_DC)
     if(strcmp(decflt_rounding, "ROUND_FLOOR") == 0) {
         rounding_mode = SQL_ROUND_FLOOR;
     }
-    rc = SQLSetConnectAttr((SQLHDBC)hdbc, SQL_ATTR_DECFLOAT_ROUNDING_MODE, (SQLPOINTER)rounding_mode, SQL_IS_INTEGER);
+    rc = SQLSetConnectAttr((SQLHDBC)hdbc, SQL_ATTR_DECFLOAT_ROUNDING_MODE, (SQLPOINTER)(intptr_t)rounding_mode, SQL_IS_INTEGER);
     
     return;
 }
@@ -3112,7 +3112,7 @@ PHP_FUNCTION(db2_autocommit)
         /* If value in handle is different from value passed in */
         if (argc == 2) {
             autocommit = value;
-            rc = SQLSetConnectAttr((SQLHDBC)conn_res->hdbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)autocommit, SQL_IS_INTEGER);
+            rc = SQLSetConnectAttr((SQLHDBC)conn_res->hdbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)(intptr_t)autocommit, SQL_IS_INTEGER);
             if ( rc == SQL_ERROR ) {
                 _php_db2_check_sql_errors((SQLHDBC)conn_res->hdbc, SQL_HANDLE_DBC, rc, 1, NULL, -1, 1 TSRMLS_CC);
                 RETURN_FALSE;
@@ -7713,7 +7713,7 @@ PHP_FUNCTION(db2_last_insert_id)
  */
 static int _ibm_db_chaining_flag( stmt_handle *stmt_res, SQLINTEGER flag, error_msg_node *error_list, int client_err_cnt TSRMLS_DC ) {
     int rc;
-    rc = SQLSetStmtAttr((SQLHSTMT)stmt_res->hstmt, flag, (SQLPOINTER)SQL_TRUE, SQL_IS_INTEGER);
+    rc = SQLSetStmtAttr((SQLHSTMT)stmt_res->hstmt, flag, (SQLPOINTER)(intptr_t)SQL_TRUE, SQL_IS_INTEGER);
     if ( flag == SQL_ATTR_CHAINING_BEGIN ) {
         if ( rc  == SQL_ERROR ) {
             php_error_docref(NULL TSRMLS_CC, E_WARNING, "Chaining begin failed");

--- a/php_ibm_db2.h
+++ b/php_ibm_db2.h
@@ -34,6 +34,20 @@ extern zend_module_entry ibm_db2_module_entry;
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1600
+#include <stdint.h>
+#else
+
+#ifdef _WIN64
+typedef int64_t intptr_t;
+typedef uint64_t uintptr_t;
+#else
+typedef int32_t intptr_t;
+typedef uint32_t uintptr_t;
+#endif
+#endif
+
 #include <sqlcli1.h>
 
 /* Needed for backward compatibility (IS_INTERNED not defined prior to PHP-5.4) */


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=76021

eg.

```
ibm_db2.c:1379:59: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
                                     SQL_ATTR_CURSOR_TYPE, (SQLPOINTER)vParam,
                                                           ^
```