### PR TITLE
Fix #81331: compile errors ibm_db2.c v2.1.3 on Windows

### DIFF
--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -1886,7 +1886,6 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
 static int _php_db2_parse_options ( zval *options, int type, void *handle )
 {
     int i = 0;
-    unsigned long num_idx;
     char *opt_key; /* Holds the Option Index Key */
     zval **data;
     zval **tc_pass = NULL;
@@ -4766,7 +4765,7 @@ PHP_FUNCTION(db2_execute)
     zval *val;
     zend_string *key,*key1;
     char str[1024] = {0};
-    unsigned long num_key;
+    zend_long num_key;
     SQLPOINTER paramValuePtr=NULL;
     SQLPOINTER valuePtr=NULL;
     SQLPOINTER valuePtr2=NULL;
@@ -7552,7 +7551,7 @@ PHP_FUNCTION( db2_execute_many )
     zend_string *key;
     zend_string *key1,*key2,*key3,*key4,*key5;
     zval *zv = NULL, *zv1 = NULL,*zv2,*zv3,*zv4,*zv5;
-    unsigned long num_key,num_key1,num_key2,num_key3,num_key4,num_key5;
+    zend_long num_key,num_key1,num_key2,num_key3,num_key4,num_key5;
     
     /* These are used to loop over the param cache*/
     param_node *tmp_curr, *prev_ptr, *curr_ptr;

--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -1886,7 +1886,7 @@ static void _php_db2_assign_options( void *handle, int type, char *opt_key, zval
 static int _php_db2_parse_options ( zval *options, int type, void *handle )
 {
     int i = 0;
-    ulong num_idx;
+    unsigned long num_idx;
     char *opt_key; /* Holds the Option Index Key */
     zval **data;
     zval **tc_pass = NULL;
@@ -4766,7 +4766,7 @@ PHP_FUNCTION(db2_execute)
     zval *val;
     zend_string *key,*key1;
     char str[1024] = {0};
-    ulong num_key;
+    unsigned long num_key;
     SQLPOINTER paramValuePtr=NULL;
     SQLPOINTER valuePtr=NULL;
     SQLPOINTER valuePtr2=NULL;
@@ -7552,7 +7552,7 @@ PHP_FUNCTION( db2_execute_many )
     zend_string *key;
     zend_string *key1,*key2,*key3,*key4,*key5;
     zval *zv = NULL, *zv1 = NULL,*zv2,*zv3,*zv4,*zv5;
-    ulong num_key,num_key1,num_key2,num_key3,num_key4,num_key5;
+    unsigned long num_key,num_key1,num_key2,num_key3,num_key4,num_key5;
     
     /* These are used to loop over the param cache*/
     param_node *tmp_curr, *prev_ptr, *curr_ptr;


### PR DESCRIPTION
As of PHP 7.4.0, the fallback definition of `ulong` has been removed
from php-src[1].  This is usually not an issue on POSIX systems where
`ulong` is pre-defined, but on Windows and some macOS environments,
where it is not.

We simply replace `ulong` with `unsigned long` for best compatibility.

[1] <https://github.com/php/php-src/pull/3905>