### PR TITLE
Bug #76322: Strings containing NULL-byte get truncated

### DIFF
--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -6239,7 +6239,7 @@ static void _php_db2_bind_fetch_helper(INTERNAL_FUNCTION_PARAMETERS, int op)
                 case SQL_DECFLOAT:
 #ifdef PASE /* i5/OS trim spaces */
                     if (stmt_res->s_i5_conn_parent->c_i5_char_trim > 0) {
-                        i5trim = strlen((char *)row_data->str_val);
+                        i5trim = out_length;
                         for(; i5trim >= 0; i5trim--) {
                             i5char = (char)(((char *)row_data->str_val)[i5trim]);
                             if (i5char == 0x00 || i5char == 0x20) {
@@ -6261,11 +6261,11 @@ static void _php_db2_bind_fetch_helper(INTERNAL_FUNCTION_PARAMETERS, int op)
 #endif /* PASE */
                     if ( op & DB2_FETCH_ASSOC ) {
                         add_assoc_stringl(return_value, (char *)stmt_res->column_info[i].name,
-                            (char *)row_data->str_val, strlen((char *)row_data->str_val));
+                            (char *)row_data->str_val, out_length);
                     }
                     if ( op & DB2_FETCH_INDEX ) {
                         add_index_stringl(return_value, i, (char *)row_data->str_val,
-                            strlen((char *)row_data->str_val));
+                            out_length);
                     }
                     break;
                 case SQL_SMALLINT:

--- a/tests/test_76322_fetch_null_byte.phpt
+++ b/tests/test_76322_fetch_null_byte.phpt
@@ -1,0 +1,23 @@
+--TEST--
+IBM-DB2: PECL bug 76322 -- strings containing null-byte get truncated
+--SKIPIF--
+<?php
+require_once('skipif3.inc');
+?>
+--FILE--
+<?php
+
+require_once('connection.inc');
+
+$conn = db2_connect($database, $user, $password);
+$stmt = db2_prepare($conn, "SELECT X'410042' V FROM sysibm.sysdummy1");
+db2_execute($stmt);
+$row = db2_fetch_both($stmt);
+
+echo bin2hex($row[0]), PHP_EOL;
+echo bin2hex($row['V']), PHP_EOL;
+
+?>
+--EXPECT--
+410042
+410042


### PR DESCRIPTION
Tested locally with [ibmcom/db2:11.5.6.0](https://hub.docker.com/r/ibmcom/db2):
```
$ make test TESTS=tests/test_76322_fetch_null_byte.phpt

Build complete.
Don't forget to run 'make test'.


=====================================================================
PHP         : /usr/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 8.0.9
ZEND_VERSION: 4.0.9
PHP_OS      : Linux - Linux viola 5.13.8-arch1-1 #1 SMP PREEMPT Wed, 04 Aug 2021 16:57:44 +0000 x86_64
INI actual  : /home/morozov/Projects/pecl-database-ibm_db2/tmp-php.ini
More .INIs  :   
CWD         : /home/morozov/Projects/pecl-database-ibm_db2
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
Running selected tests.
PASS IBM-DB2: PECL bug 76322 -- strings containing null-byte get truncated [tests/test_76322_fetch_null_byte.phpt] 
=====================================================================
Number of tests :    1                 1
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :    1 (100.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :    5 seconds
=====================================================================
```