### PR TITLE
Include password in persistent hash key

### DIFF
--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -2354,10 +2354,11 @@ static int _php_db2_connect_helper( INTERNAL_FUNCTION_PARAMETERS, conn_handle **
         /* Check if we already have a connection for this userID & database combination */
         if (isPersistent) {
             zend_resource *entry;
-            hKeyLen = strlen(database) + strlen(uid) + 8;
+            hKeyLen = strlen(database) + strlen(uid) + strlen(password) + 9;
             hKey = (char *) ecalloc(1, hKeyLen);
 
-            sprintf(hKey, "__db2_%s.%s", uid, database);
+            /* XXX: How do we include the options (array) in here too? */
+            sprintf(hKey, "__db2_%s.%s.%s", uid, database, password);
             temp = zend_hash_str_find_ptr(&EG(persistent_list), hKey, hKeyLen );
             if ( temp && temp->type == le_pconn_struct) {   
                 conn_res = *pconn_res = (conn_handle *)temp->ptr;

--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -2354,6 +2354,7 @@ static int _php_db2_connect_helper( INTERNAL_FUNCTION_PARAMETERS, conn_handle **
         /* Check if we already have a connection for this userID & database combination */
         if (isPersistent) {
             zend_resource *entry;
+            /* 9 = strlen("__db2_") + strlen('.') + strlen(".") + null */
             hKeyLen = strlen(database) + strlen(uid) + strlen(password) + 9;
             hKey = (char *) ecalloc(1, hKeyLen);
 

--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -2368,8 +2368,8 @@ static int _php_db2_connect_helper( INTERNAL_FUNCTION_PARAMETERS, conn_handle **
         /* Check if we already have a connection for this userID & database combination */
         if (isPersistent) {
             zend_resource *entry;
-            /* 17 = strlen("FFFFFFFF") + strlen("__db2_") + strlen(".") + strlen(".") + null */
-            hKeyLen = strlen(database) + strlen(uid) + 17;
+            hKeyLen = strlen(database) + strlen(uid) +
+                sizeof("__db2_..FFFFFFFF"); /* constant part; includes null */
             hKey = (char *) ecalloc(1, hKeyLen);
 
             /* XXX: How do we include the options (array) in here too? */

--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -351,8 +351,21 @@ static void _php_db2_set_symbol(char * varname, zval *var)
 }
 /* }}} */
 
+/* {{{ Murmur hash implementation (for persistent key hash)
+ */
 
+static unsigned int _php_db2_MurmurOAAT32 (const char * key)
+{
+    unsigned int h = 3323198485;
+    for (;*key;++key) {
+        h ^= *key;
+        h *= 0x5bd1e995;
+        h ^= h >> 15;
+    }
+    return h;
+}
 
+/* }}} */
 
 #ifdef PASE /* IBM i meta change ""->NULL */
 static void _php_db2_meta_helper(SQLCHAR **qualifier, size_t *qualifier_len,
@@ -2313,6 +2326,7 @@ static int _php_db2_connect_helper( INTERNAL_FUNCTION_PARAMETERS, conn_handle **
     int reused = 0;
     int hKeyLen = 0;
     char *hKey = NULL;
+    unsigned int password_hashed;
     char server[2048];
     int attr = SQL_TRUE;
     size_t database_len;
@@ -2354,12 +2368,13 @@ static int _php_db2_connect_helper( INTERNAL_FUNCTION_PARAMETERS, conn_handle **
         /* Check if we already have a connection for this userID & database combination */
         if (isPersistent) {
             zend_resource *entry;
-            /* 9 = strlen("__db2_") + strlen('.') + strlen(".") + null */
-            hKeyLen = strlen(database) + strlen(uid) + strlen(password) + 9;
+            /* 17 = strlen("FFFFFFFF") strlen("__db2_") + strlen('.') + strlen(".") + null */
+            hKeyLen = strlen(database) + strlen(uid) + 17;
             hKey = (char *) ecalloc(1, hKeyLen);
 
             /* XXX: How do we include the options (array) in here too? */
-            sprintf(hKey, "__db2_%s.%s.%s", uid, database, password);
+            password_hashed = _php_db2_MurmurOAAT32(password);
+            snprintf(hKey, hKeyLen, "__db2_%s.%s.%08x", uid, database, password_hashed);
             temp = zend_hash_str_find_ptr(&EG(persistent_list), hKey, hKeyLen );
             if ( temp && temp->type == le_pconn_struct) {   
                 conn_res = *pconn_res = (conn_handle *)temp->ptr;

--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -2368,7 +2368,7 @@ static int _php_db2_connect_helper( INTERNAL_FUNCTION_PARAMETERS, conn_handle **
         /* Check if we already have a connection for this userID & database combination */
         if (isPersistent) {
             zend_resource *entry;
-            /* 17 = strlen("FFFFFFFF") strlen("__db2_") + strlen('.') + strlen(".") + null */
+            /* 17 = strlen("FFFFFFFF") + strlen("__db2_") + strlen(".") + strlen(".") + null */
             hKeyLen = strlen(database) + strlen(uid) + 17;
             hKey = (char *) ecalloc(1, hKeyLen);
 

--- a/tests/test_222_PersistentConnReuseWithBadPassword.phpt
+++ b/tests/test_222_PersistentConnReuseWithBadPassword.phpt
@@ -1,0 +1,31 @@
+--TEST--
+IBM-DB2: db2_pconnect() - test persistent connection won't be reused with bad password
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+require_once('connection.inc');
+
+/*
+ * Use blatantly incorrect password, to make sure password is part of the
+ * internal persistent connection hash.
+ */
+$conn1 = db2_pconnect($database, $user, $password);
+if ($conn1) {
+    $conn2 = db2_pconnect($database, $user, "wrongbad");
+    if ($conn2) {
+        echo "A bad password was accepted.\n";
+        db2_close($conn2);
+    } else {
+        echo "OK\n";
+    }
+    db2_close($conn1);
+}
+else {
+    echo "Connection failed.\n";
+}
+
+?>
+--EXPECT--
+OK


### PR DESCRIPTION
Matches behaviour of other database extensions, and removes some surprise that the extension doesn't check for a valid password when reusing a connection. Of course, that must be the password the connection was created with, but that's the same for the others too.

Fixes GH-18

XXX: Would like to include options, but not sure how to do this cleanly.