### PR TITLE
Update `ibm_db2.stub.php`

### DIFF
--- a/ibm_db2.stub.php
+++ b/ibm_db2.stub.php
@@ -4,7 +4,7 @@
  * Stub for arginfo in PHP 8
  * XXX: How do we represent optionals without defaults?
  * @generate-function-entries
- * @generate-legacy-arginfo
+ * @generate-legacy-arginfo 70000
  */
 
 /**
@@ -27,7 +27,7 @@ function db2_pconnect(string $database, ?string $username, ?string $password, ar
 /**
  * @param resource $connection
  */
-function db2_autocommit($connection, ?int $value = null): int|bool {}
+function db2_autocommit($connection, int $value = UNKNOWN): int|bool {}
 
 /**
  * @param resource $connection
@@ -43,7 +43,7 @@ function db2_close($connection): bool {}
 /**
  * @param resource $connection
  */
-function db2_pclose( $connection): bool {}
+function db2_pclose($connection): bool {}
 #endif
 
 /**
@@ -121,7 +121,7 @@ function db2_special_columns($connection, ?string $qualifier, string $schema, st
  * @return resource
  * @alias db2_special_columns
  */
-function db2_specialcolumns(resource $connection, ?string $qualifier, string $schema, string $table_name, int $scope) {}
+function db2_specialcolumns($connection, ?string $qualifier, string $schema, string $table_name, int $scope) {}
 
 /**
  * @param resource $connection
@@ -175,22 +175,22 @@ function db2_execute_many($stmt, array $options = []): int|false {}
 #endif
 
 /**
- * @param resource $stmt
+ * @param resource|null $stmt
  */
 function db2_stmt_errormsg($stmt = null): string {}
 
 /**
- * @param resource $stmt
+ * @param resource|null $stmt
  */
 function db2_stmt_error($stmt = null): string {}
 
 /**
- * @param resource $connection
+ * @param resource|null $connection
  */
 function db2_conn_errormsg($connection = null): string {}
 
 /**
- * @param resource $connection
+ * @param resource|null $connection
  */
 function db2_conn_error($connection = null): string {}
 

--- a/ibm_db2_arginfo.h
+++ b/ibm_db2_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6178723de1b801eade1e4e7251805f53f100fee3 */
+ * Stub hash: 3e863612a7a676e042e024f6778b791bd086abe5 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_connect, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, database, IS_STRING, 0)
@@ -16,7 +16,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_db2_autocommit, 0, 1, MAY_BE_LONG|MAY_BE_BOOL)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_db2_bind_param, 0, 3, _IS_BOOL, 0)
@@ -87,13 +87,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_special_columns, 0, 0, 5)
 	ZEND_ARG_TYPE_INFO(0, scope, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_specialcolumns, 0, 0, 5)
-	ZEND_ARG_OBJ_INFO(0, connection, resource, 0)
-	ZEND_ARG_TYPE_INFO(0, qualifier, IS_STRING, 1)
-	ZEND_ARG_TYPE_INFO(0, schema, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, table_name, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, scope, IS_LONG, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_db2_specialcolumns arginfo_db2_special_columns
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_statistics, 0, 0, 5)
 	ZEND_ARG_INFO(0, connection)

--- a/ibm_db2_legacy_arginfo.h
+++ b/ibm_db2_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6178723de1b801eade1e4e7251805f53f100fee3 */
+ * Stub hash: 3e863612a7a676e042e024f6778b791bd086abe5 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_connect, 0, 0, 3)
 	ZEND_ARG_INFO(0, database)


### PR DESCRIPTION
* Argument 2 for `db2_autocommit()` is optional, but not nullable;
* Argument 1 in `db2_stmt_errormsg()`, `db2_stmt_error()`, `db2_conn_errormsg()` and `db2_conn_error()` was explicitly declared as nullable;
* The `resource` type declaration was removed from argument 1 in `db2_specialcolumns()`, as is not available (see https://wiki.php.net/rfc/resource_typehint).