### PR TITLE
Use camel case for parameter names in `ibm_db2.stub.php`

### DIFF
--- a/ibm_db2.stub.php
+++ b/ibm_db2.stub.php
@@ -32,7 +32,7 @@ function db2_autocommit($connection, int $value = UNKNOWN): int|bool {}
 /**
  * @param resource $connection
  */
-function db2_bind_param($connection, int $parameter_number, string $variable_name, int $parameter_type = DB2_PARAM_IN, int $data_type = 0, int $precision = -1, int $scale = 0): bool {}
+function db2_bind_param($connection, int $parameterNumber, string $variableName, int $parameterType = DB2_PARAM_IN, int $dataType = 0, int $precision = -1, int $scale = 0): bool {}
 
 /**
  * @param resource $connection
@@ -50,46 +50,46 @@ function db2_pclose($connection): bool {}
  * @param resource $connection
  * @return resource
  */
-function db2_column_privileges($connection, ?string $qualifier = null, ?string $schema = null, ?string $table_name = null, ?string $column_name = null) {}
+function db2_column_privileges($connection, ?string $qualifier = null, ?string $schema = null, ?string $tableName = null, ?string $columnName = null) {}
 
 /**
  * @param resource $connection
  * @return resource
  * @alias db2_column_privileges
  */
-function db2_columnprivileges($connection, ?string $qualifier = null, ?string $schema = null, ?string $table_name = null, ?string $column_name = null) {}
+function db2_columnprivileges($connection, ?string $qualifier = null, ?string $schema = null, ?string $tableName = null, ?string $columnName = null) {}
 
 /**
  * @param resource $connection
  * @return resource
  */
-function db2_columns($connection, ?string $qualifier = null, ?string $schema = null, ?string $table_name = null, ?string $column_name = null) {}
+function db2_columns($connection, ?string $qualifier = null, ?string $schema = null, ?string $tableName = null, ?string $columnName = null) {}
 
 /**
  * @param resource $connection
  * @return resource
  */
-function db2_foreign_keys($connection, ?string $qualifier, ?string $schema, string $table_name) {}
+function db2_foreign_keys($connection, ?string $qualifier, ?string $schema, string $tableName) {}
 
 /**
  * @param resource $connection
  * @return resource
  * @alias db2_foreign_keys
  */
-function db2_foreignkeys($connection, ?string $qualifier, ?string $schema, string $table_name) {}
+function db2_foreignkeys($connection, ?string $qualifier, ?string $schema, string $tableName) {}
 
 /**
  * @param resource $connection
  * @return resource
  */
-function db2_primary_keys($connection, ?string $qualifier, ?string $schema, string $table_name) {}
+function db2_primary_keys($connection, ?string $qualifier, ?string $schema, string $tableName) {}
 
 /**
  * @param resource $connection
  * @return resource
  * @alias db2_primary_keys
  */
-function db2_primarykeys($connection, ?string $qualifier, ?string $schema, string $table_name) {}
+function db2_primarykeys($connection, ?string $qualifier, ?string $schema, string $tableName) {}
 
 /**
  * @param resource $connection
@@ -114,39 +114,39 @@ function db2_procedures($connection, ?string $qualifier, string $schema, string 
  * @param resource $connection
  * @return resource
  */
-function db2_special_columns($connection, ?string $qualifier, string $schema, string $table_name, int $scope) {}
+function db2_special_columns($connection, ?string $qualifier, string $schema, string $tableName, int $scope) {}
 
 /**
  * @param resource $connection
  * @return resource
  * @alias db2_special_columns
  */
-function db2_specialcolumns($connection, ?string $qualifier, string $schema, string $table_name, int $scope) {}
+function db2_specialcolumns($connection, ?string $qualifier, string $schema, string $tableName, int $scope) {}
 
 /**
  * @param resource $connection
  * @return resource
  */
-function db2_statistics($connection, ?string $qualifier, ?string $schema, string $table_name, bool|int $unique) {}
+function db2_statistics($connection, ?string $qualifier, ?string $schema, string $tableName, bool|int $unique) {}
 
 /**
  * @param resource $connection
  * @return resource
  */
-function db2_table_privileges($connection, ?string $qualifier = null, ?string $schema = null, ?string $table_name = null) {}
+function db2_table_privileges($connection, ?string $qualifier = null, ?string $schema = null, ?string $tableName = null) {}
 
 /**
  * @param resource $connection
  * @return resource
  * @alias db2_table_privileges
  */
-function db2_tableprivileges($connection, ?string $qualifier = null, ?string $schema = null, ?string $table_name = null) {}
+function db2_tableprivileges($connection, ?string $qualifier = null, ?string $schema = null, ?string $tableName = null) {}
 
 /**
  * @param resource $connection
  * @return resource
  */
-function db2_tables($connection, ?string $qualifier = null, ?string $schema = null, ?string $table_name = null, ?string $table_type = null) {}
+function db2_tables($connection, ?string $qualifier = null, ?string $schema = null, ?string $tableName = null, ?string $tableType = null) {}
 
 /**
  * @param resource $connection
@@ -177,22 +177,22 @@ function db2_execute_many($stmt, array $options = []): int|false {}
 /**
  * @param resource|null $stmt
  */
-function db2_stmt_errormsg($stmt = null): string {}
+function db2_stmt_errormsg($stmt = UNKNOWN): string {}
 
 /**
  * @param resource|null $stmt
  */
-function db2_stmt_error($stmt = null): string {}
+function db2_stmt_error($stmt = UNKNOWN): string {}
 
 /**
  * @param resource|null $connection
  */
-function db2_conn_errormsg($connection = null): string {}
+function db2_conn_errormsg($connection = UNKNOWN): string {}
 
 /**
  * @param resource|null $connection
  */
-function db2_conn_error($connection = null): string {}
+function db2_conn_error($connection = UNKNOWN): string {}
 
 /**
  * @param resource $stmt
@@ -268,27 +268,27 @@ function db2_result($stmt, int|string $column): mixed|null {}
 /**
  * @param resource $stmt
  */
-function db2_fetch_row($stmt, ?int $row_number = null): bool {}
+function db2_fetch_row($stmt, ?int $rowNumber = null): bool {}
 
 /**
  * @param resource $stmt
  */
-function db2_fetch_assoc($stmt, ?int $row_number = null): array|false {}
+function db2_fetch_assoc($stmt, ?int $rowNumber = null): array|false {}
 
 /**
  * @param resource $stmt
  */
-function db2_fetch_array($stmt, ?int $row_number = null): array|false {}
+function db2_fetch_array($stmt, ?int $rowNumber = null): array|false {}
 
 /**
  * @param resource $stmt
  */
-function db2_fetch_both($stmt, ?int $row_number = null): array|false {}
+function db2_fetch_both($stmt, ?int $rowNumber = null): array|false {}
 
 /**
  * @param resource $stmt
  */
-function db2_fetch_object($stmt, ?int $row_number = null): \stdClass|false {}
+function db2_fetch_object($stmt, ?int $rowNumber = null): \stdClass|false {}
 
 /**
  * @param resource $stmt
@@ -316,12 +316,12 @@ function db2_client_info($connection): \stdClass|false {}
  */
 function db2_server_info($connection): \stdClass|false {}
 
-function db2_escape_string(string $string_literal): string {}
+function db2_escape_string(string $stringLiteral): string {}
 
 /**
  * @param resource $stmt
  */
-function db2_lob_read($stmt, int $colnum, int $length): string|false {}
+function db2_lob_read($stmt, int $columnNumber, int $length): string|false {}
 
 /**
  * @param resource $resource

--- a/ibm_db2_arginfo.h
+++ b/ibm_db2_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e952caf6e14487291104ab1f1fdd7f268cc8a6bc */
+ * Stub hash: 068c5c0eb15d14238885a5bacfe55e6cfac5cb6a */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_connect, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, database, IS_STRING, 0)
@@ -21,10 +21,10 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_db2_bind_param, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_TYPE_INFO(0, parameter_number, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, variable_name, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, parameter_type, IS_LONG, 0, "DB2_PARAM_IN")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, data_type, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO(0, parameterNumber, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, variableName, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, parameterType, IS_LONG, 0, "DB2_PARAM_IN")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dataType, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, precision, IS_LONG, 0, "-1")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, scale, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
@@ -41,8 +41,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_column_privileges, 0, 0, 1)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, qualifier, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, schema, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, table_name, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, column_name, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tableName, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, columnName, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_db2_columnprivileges arginfo_db2_column_privileges
@@ -53,7 +53,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_foreign_keys, 0, 0, 4)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_TYPE_INFO(0, qualifier, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, schema, IS_STRING, 1)
-	ZEND_ARG_TYPE_INFO(0, table_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, tableName, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_db2_foreignkeys arginfo_db2_foreign_keys
@@ -83,7 +83,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_special_columns, 0, 0, 5)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_TYPE_INFO(0, qualifier, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, schema, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, table_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, tableName, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, scope, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
@@ -93,7 +93,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_statistics, 0, 0, 5)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_TYPE_INFO(0, qualifier, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, schema, IS_STRING, 1)
-	ZEND_ARG_TYPE_INFO(0, table_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, tableName, IS_STRING, 0)
 	ZEND_ARG_TYPE_MASK(0, unique, MAY_BE_BOOL|MAY_BE_LONG, NULL)
 ZEND_END_ARG_INFO()
 
@@ -101,7 +101,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_table_privileges, 0, 0, 1)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, qualifier, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, schema, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, table_name, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tableName, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_db2_tableprivileges arginfo_db2_table_privileges
@@ -110,8 +110,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_tables, 0, 0, 1)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, qualifier, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, schema, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, table_name, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, table_type, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tableName, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tableType, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_exec, 0, 0, 2)
@@ -135,13 +135,13 @@ ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_db2_stmt_errormsg, 0, 0, IS_STRING, 0)
-	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, stmt, "null")
+	ZEND_ARG_INFO(0, stmt)
 ZEND_END_ARG_INFO()
 
 #define arginfo_db2_stmt_error arginfo_db2_stmt_errormsg
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_db2_conn_errormsg, 0, 0, IS_STRING, 0)
-	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, connection, "null")
+	ZEND_ARG_INFO(0, connection)
 ZEND_END_ARG_INFO()
 
 #define arginfo_db2_conn_error arginfo_db2_conn_errormsg
@@ -193,12 +193,12 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_db2_fetch_row, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, stmt)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row_number, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, rowNumber, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_db2_fetch_assoc, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, stmt)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row_number, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, rowNumber, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_db2_fetch_array arginfo_db2_fetch_assoc
@@ -207,7 +207,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_db2_fetch_object, 0, 1, stdClass, MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, stmt)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row_number, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, rowNumber, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_db2_free_result arginfo_db2_free_stmt
@@ -227,12 +227,12 @@ ZEND_END_ARG_INFO()
 #define arginfo_db2_server_info arginfo_db2_client_info
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_db2_escape_string, 0, 1, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, string_literal, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, stringLiteral, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_db2_lob_read, 0, 3, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, stmt)
-	ZEND_ARG_TYPE_INFO(0, colnum, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, columnNumber, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, length, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 

--- a/ibm_db2_legacy_arginfo.h
+++ b/ibm_db2_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e952caf6e14487291104ab1f1fdd7f268cc8a6bc */
+ * Stub hash: 068c5c0eb15d14238885a5bacfe55e6cfac5cb6a */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_connect, 0, 0, 3)
 	ZEND_ARG_INFO(0, database)
@@ -21,10 +21,10 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_bind_param, 0, 0, 3)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_INFO(0, parameter_number)
-	ZEND_ARG_INFO(0, variable_name)
-	ZEND_ARG_INFO(0, parameter_type)
-	ZEND_ARG_INFO(0, data_type)
+	ZEND_ARG_INFO(0, parameterNumber)
+	ZEND_ARG_INFO(0, variableName)
+	ZEND_ARG_INFO(0, parameterType)
+	ZEND_ARG_INFO(0, dataType)
 	ZEND_ARG_INFO(0, precision)
 	ZEND_ARG_INFO(0, scale)
 ZEND_END_ARG_INFO()
@@ -41,8 +41,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_column_privileges, 0, 0, 1)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_INFO(0, qualifier)
 	ZEND_ARG_INFO(0, schema)
-	ZEND_ARG_INFO(0, table_name)
-	ZEND_ARG_INFO(0, column_name)
+	ZEND_ARG_INFO(0, tableName)
+	ZEND_ARG_INFO(0, columnName)
 ZEND_END_ARG_INFO()
 
 #define arginfo_db2_columnprivileges arginfo_db2_column_privileges
@@ -53,7 +53,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_foreign_keys, 0, 0, 4)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_INFO(0, qualifier)
 	ZEND_ARG_INFO(0, schema)
-	ZEND_ARG_INFO(0, table_name)
+	ZEND_ARG_INFO(0, tableName)
 ZEND_END_ARG_INFO()
 
 #define arginfo_db2_foreignkeys arginfo_db2_foreign_keys
@@ -83,7 +83,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_special_columns, 0, 0, 5)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_INFO(0, qualifier)
 	ZEND_ARG_INFO(0, schema)
-	ZEND_ARG_INFO(0, table_name)
+	ZEND_ARG_INFO(0, tableName)
 	ZEND_ARG_INFO(0, scope)
 ZEND_END_ARG_INFO()
 
@@ -93,7 +93,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_statistics, 0, 0, 5)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_INFO(0, qualifier)
 	ZEND_ARG_INFO(0, schema)
-	ZEND_ARG_INFO(0, table_name)
+	ZEND_ARG_INFO(0, tableName)
 	ZEND_ARG_INFO(0, unique)
 ZEND_END_ARG_INFO()
 
@@ -101,7 +101,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_table_privileges, 0, 0, 1)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_INFO(0, qualifier)
 	ZEND_ARG_INFO(0, schema)
-	ZEND_ARG_INFO(0, table_name)
+	ZEND_ARG_INFO(0, tableName)
 ZEND_END_ARG_INFO()
 
 #define arginfo_db2_tableprivileges arginfo_db2_table_privileges
@@ -110,8 +110,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_tables, 0, 0, 1)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_INFO(0, qualifier)
 	ZEND_ARG_INFO(0, schema)
-	ZEND_ARG_INFO(0, table_name)
-	ZEND_ARG_INFO(0, table_type)
+	ZEND_ARG_INFO(0, tableName)
+	ZEND_ARG_INFO(0, tableType)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_exec, 0, 0, 2)
@@ -181,7 +181,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_fetch_row, 0, 0, 1)
 	ZEND_ARG_INFO(0, stmt)
-	ZEND_ARG_INFO(0, row_number)
+	ZEND_ARG_INFO(0, rowNumber)
 ZEND_END_ARG_INFO()
 
 #define arginfo_db2_fetch_assoc arginfo_db2_fetch_row
@@ -207,12 +207,12 @@ ZEND_END_ARG_INFO()
 #define arginfo_db2_server_info arginfo_db2_commit
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_escape_string, 0, 0, 1)
-	ZEND_ARG_INFO(0, string_literal)
+	ZEND_ARG_INFO(0, stringLiteral)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_lob_read, 0, 0, 3)
 	ZEND_ARG_INFO(0, stmt)
-	ZEND_ARG_INFO(0, colnum)
+	ZEND_ARG_INFO(0, columnNumber)
 	ZEND_ARG_INFO(0, length)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
The parameter `$colnum` in `db2_lob_read()` was also renamed to `$columnNumber`;

**TODO**:
- [x] Wait for #32.