### PR TITLE
Update parameter name from `$colnum` to `$column_number` in `db2_lob_read()`

### DIFF
--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -7280,11 +7280,11 @@ PHP_FUNCTION(db2_lob_read)
     stmt_handle *stmt_res;
     int rc, i = 0;
     SQLINTEGER out_length;
-    zend_long length=BUFSIZ, colnum = 1;
+    zend_long length=BUFSIZ, column_number = 1;
     void *out_ptr = NULL;
 
     /* Parse out the parameters */
-    if (zend_parse_parameters(argc, "rll", &stmt, &colnum, &length) == FAILURE) {
+    if (zend_parse_parameters(argc, "rll", &stmt, &column_number, &length) == FAILURE) {
         return;
     }
 
@@ -7304,7 +7304,7 @@ PHP_FUNCTION(db2_lob_read)
 #else
     out_ptr = (SQLPOINTER)ecalloc(1, ++length);
 #endif /* PASE */
-    rc = SQLGetData((SQLHSTMT)stmt_res->hstmt, colnum, SQL_C_CHAR, (SQLPOINTER)out_ptr, length, &out_length);
+    rc = SQLGetData((SQLHSTMT)stmt_res->hstmt, column_number, SQL_C_CHAR, (SQLPOINTER)out_ptr, length, &out_length);
     if ( rc == SQL_NO_DATA_FOUND ) {
         _php_db2_check_sql_errors(stmt_res->hstmt, SQL_HANDLE_STMT, rc, 1, NULL, -1, 1);
         efree(out_ptr);

--- a/ibm_db2.stub.php
+++ b/ibm_db2.stub.php
@@ -321,7 +321,7 @@ function db2_escape_string(string $string_literal): string {}
 /**
  * @param resource $stmt
  */
-function db2_lob_read($stmt, int $colnum, int $length): string|false {}
+function db2_lob_read($stmt, int $column_number, int $length): string|false {}
 
 /**
  * @param resource $resource

--- a/ibm_db2_arginfo.h
+++ b/ibm_db2_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f4efdc4aa065c8af4c96b20b6f555f3abfdeb08e */
+ * Stub hash: cf2e16686d6f87e61b92c216535237c9ca414805 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_connect, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, database, IS_STRING, 0)
@@ -232,7 +232,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_db2_lob_read, 0, 3, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, stmt)
-	ZEND_ARG_TYPE_INFO(0, colnum, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, column_number, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, length, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 

--- a/ibm_db2_legacy_arginfo.h
+++ b/ibm_db2_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f4efdc4aa065c8af4c96b20b6f555f3abfdeb08e */
+ * Stub hash: cf2e16686d6f87e61b92c216535237c9ca414805 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_connect, 0, 0, 3)
 	ZEND_ARG_INFO(0, database)
@@ -212,7 +212,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_lob_read, 0, 0, 3)
 	ZEND_ARG_INFO(0, stmt)
-	ZEND_ARG_INFO(0, colnum)
+	ZEND_ARG_INFO(0, column_number)
 	ZEND_ARG_INFO(0, length)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
Just for consistency with the other functions where parameters like `$column_name` are used.