### PR TITLE
Update allowed type and default value for the `$row_number` parameter in several "fetch" functions

### DIFF
--- a/ibm_db2.stub.php
+++ b/ibm_db2.stub.php
@@ -268,27 +268,27 @@ function db2_result($stmt, int|string $column): mixed|null {}
 /**
  * @param resource $stmt
  */
-function db2_fetch_row($stmt, ?int $row_number = null): bool {}
+function db2_fetch_row($stmt, int $row_number = UNKNOWN): bool {}
 
 /**
  * @param resource $stmt
  */
-function db2_fetch_assoc($stmt, ?int $row_number = null): array|false {}
+function db2_fetch_assoc($stmt, int $row_number = -1): array|false {}
 
 /**
  * @param resource $stmt
  */
-function db2_fetch_array($stmt, ?int $row_number = null): array|false {}
+function db2_fetch_array($stmt, int $row_number = -1): array|false {}
 
 /**
  * @param resource $stmt
  */
-function db2_fetch_both($stmt, ?int $row_number = null): array|false {}
+function db2_fetch_both($stmt, int $row_number = -1): array|false {}
 
 /**
  * @param resource $stmt
  */
-function db2_fetch_object($stmt, ?int $row_number = null): \stdClass|false {}
+function db2_fetch_object($stmt, int $row_number = -1): \stdClass|false {}
 
 /**
  * @param resource $stmt

--- a/ibm_db2_arginfo.h
+++ b/ibm_db2_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0e66cf0b41d69fa0aa1514436de097e2b9d53adf */
+ * Stub hash: 2918ff411a4be42877599d8e5e2ea6c808c46803 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_connect, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, database, IS_STRING, 0)
@@ -193,12 +193,12 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_db2_fetch_row, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, stmt)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row_number, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO(0, row_number, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_db2_fetch_assoc, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, stmt)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row_number, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row_number, IS_LONG, 0, "-1")
 ZEND_END_ARG_INFO()
 
 #define arginfo_db2_fetch_array arginfo_db2_fetch_assoc
@@ -207,7 +207,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_db2_fetch_object, 0, 1, stdClass, MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, stmt)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row_number, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row_number, IS_LONG, 0, "-1")
 ZEND_END_ARG_INFO()
 
 #define arginfo_db2_free_result arginfo_db2_free_stmt

--- a/ibm_db2_legacy_arginfo.h
+++ b/ibm_db2_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0e66cf0b41d69fa0aa1514436de097e2b9d53adf */
+ * Stub hash: 2918ff411a4be42877599d8e5e2ea6c808c46803 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_connect, 0, 0, 3)
 	ZEND_ARG_INFO(0, database)


### PR DESCRIPTION
See https://github.com/php/pecl-database-ibm_db2/blob/07ff9a516b84ddd5e7245a7f660584ae4561a1a2/ibm_db2.c#L6141.

I'll try to create a new PR about `db2_fetch_row()` in order to make it consistent with these methods.