### PR TITLE
Argument 1 in `db2_connect()` and `db2_pconnect()` can contain the connection password

### DIFF
--- a/ibm_db2.stub.php
+++ b/ibm_db2.stub.php
@@ -11,7 +11,7 @@
  * @param resource $connection
  * @return resource|false
  */
-function db2_connect(string $database, ?string $username, #[\SensitiveParameter] ?string $password, array $options = []) {}
+function db2_connect(#[\SensitiveParameter] string $database, ?string $username, #[\SensitiveParameter] ?string $password, array $options = []) {}
 
 /**
  * @param resource $connection
@@ -22,7 +22,7 @@ function db2_commit($connection): bool {}
  * @param resource $connection
  * @return resource|false
  */
-function db2_pconnect(string $database, ?string $username, #[\SensitiveParameter] ?string $password, array $options = []) {}
+function db2_pconnect(#[\SensitiveParameter] string $database, ?string $username, #[\SensitiveParameter] ?string $password, array $options = []) {}
 
 /**
  * @param resource $connection

--- a/ibm_db2_arginfo.h
+++ b/ibm_db2_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4007e338d00e0ff39a6cbf06a28aafed7969550d */
+ * Stub hash: 0ca3175a9bfc7470cae69cc7b8930d4360a8d44b */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_connect, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, database, IS_STRING, 0)

--- a/ibm_db2_legacy_arginfo.h
+++ b/ibm_db2_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4007e338d00e0ff39a6cbf06a28aafed7969550d */
+ * Stub hash: 0ca3175a9bfc7470cae69cc7b8930d4360a8d44b */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_db2_connect, 0, 0, 3)
 	ZEND_ARG_INFO(0, database)


### PR DESCRIPTION
When passing a DSN string as argument 1 for `db2_connect()` and `db2_pconnect()`, it can contain the connection password in the `PWD` option.
By instance:

```php
db2_connect(
    'DRIVER={IBM DB2 ODBC DRIVER};HOSTNAME=127.0.1;PORT=50000;DATABASE=MYDB;UID=MYUSER;PWD=SECRET;',
    null,
    null
);
```