### PR TITLE
Boolean support

### DIFF
--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -2123,6 +2123,7 @@ static int _php_db2_bind_column_helper(stmt_handle *stmt_res)
                 break;
 
             case SQL_BOOLEAN:
+            case SQL_BIT:
                 rc = SQLBindCol((SQLHSTMT)stmt_res->hstmt, (SQLUSMALLINT)(i + 1),
                     SQL_C_LONG, &row_data->i_val, sizeof(row_data->i_val),
                     (SQLINTEGER *)(&stmt_res->row_data[i].out_length));
@@ -4454,6 +4455,7 @@ static int _php_db2_bind_data( stmt_handle *stmt_res, param_node *curr, zval **b
 
     switch ( curr->data_type ) {
         case SQL_BOOLEAN:
+        case SQL_BIT:
         case SQL_SMALLINT:
         case SQL_INTEGER:
         case SQL_REAL:
@@ -5492,6 +5494,7 @@ PHP_FUNCTION(db2_field_type)
     }
     switch (stmt_res->column_info[col].type) {
         case SQL_BOOLEAN:
+        case SQL_BIT:
             str_val = "boolean";
             break;
         case SQL_SMALLINT:
@@ -5946,6 +5949,7 @@ PHP_FUNCTION(db2_result)
 
             /* BOOLEAN can't be represented as true/false because false is considered an error */
             case SQL_BOOLEAN:
+            case SQL_BIT:
             case SQL_SMALLINT:
             case SQL_INTEGER:
                 rc = _php_db2_get_data(stmt_res, col_num+1, SQL_C_LONG, (SQLPOINTER)&long_val, sizeof(long_val), &out_length);
@@ -6306,6 +6310,7 @@ static void _php_db2_bind_fetch_helper(INTERNAL_FUNCTION_PARAMETERS, int op)
                     }
                     break;
                 case SQL_BOOLEAN:
+                case SQL_BIT:
                     if ( op & DB2_FETCH_ASSOC ) {
                         add_assoc_bool(return_value, (char *)stmt_res->column_info[i].name, row_data->i_val);
                     }

--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -5532,6 +5532,7 @@ PHP_FUNCTION(db2_field_type)
             str_val = "timestamp";
             break;
         default:
+fprintf(stderr, " ! Type that's string: %d\n", stmt_res->column_info[col].type);
             str_val = "string";
             break;
     }

--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -5532,7 +5532,6 @@ PHP_FUNCTION(db2_field_type)
             str_val = "timestamp";
             break;
         default:
-fprintf(stderr, " ! Type that's string: %d\n", stmt_res->column_info[col].type);
             str_val = "string";
             break;
     }

--- a/php_ibm_db2_int.h
+++ b/php_ibm_db2_int.h
@@ -15,6 +15,14 @@ typedef uint32_t uintptr_t;
 #endif
 #endif
 
+/*
+ * Added in IBM i 7.5, also in LUW 11.1 MP1/FP1
+ * see: https://www.ibm.com/docs/en/db2/11.1?topic=database-mod-pack-fix-pack-updates#c0061179__FP1
+ */
+#ifndef SQL_BOOLEAN
+#define SQL_BOOLEAN 16
+#endif
+
 /* Needed for backward compatibility (SQL_ATTR_DBC_SYS_NAMING not defined prior to DB2 10.1.0.2) */
 #ifndef SQL_ATTR_DBC_SYS_NAMING
 #define SQL_ATTR_DBC_SYS_NAMING 3017

--- a/tests/test_boolean.phpt
+++ b/tests/test_boolean.phpt
@@ -1,0 +1,61 @@
+--TEST--
+IBM-DB2: Boolean data type test.
+--SKIPIF--
+<?php
+
+require_once('skipif.inc');
+
+// This test requires IBM i 7.5 or a version of LUW that supports boolean
+require_once('connection.inc');
+$conn = db2_connect($database, $user, $password);
+if (!$conn) {
+	die("skip can't connect to DB:" . db2_conn_errormsg());
+}
+
+$info = db2_server_info($conn);
+if ($info->DBMS_NAME == "AS") { // IBM i
+	// DBMS_VER is VVRRM string
+	$major = $info[1];
+	$minor = $info[3];
+	$mod = $info[4];
+	if (!version_compare("$major.$minor.$mod", "7.5.0", ">=")) {
+		die("skip IBM i version too old");
+	}
+}
+// XXX: LUW, z
+
+?>
+--FILE--
+<?php
+
+require_once('connection.inc');
+$conn = db2_connect($database, $user, $password);
+
+if (!$conn) {
+	echo "Error connecting to database " . db2_conn_errormsg() ."\n";
+	exit;
+}
+
+$s = db2_exec("values (true, false)");
+$r = db2_fetch_array($s);
+var_dump($r);
+
+$s = db2_exec("values (true, false)");
+db2_fetch_row($s);
+var_dump(db2_result($s, 0));
+var_dump(db2_result($s, 1));
+echo db2_field_type($s, 1) . "\n";
+
+db2_close($conn);
+
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  bool(true)
+  [1]=>
+  bool(false)
+}
+bool(true)
+bool(false)
+boolean

--- a/tests/test_boolean.phpt
+++ b/tests/test_boolean.phpt
@@ -56,6 +56,6 @@ array(2) {
   [1]=>
   bool(false)
 }
-bool(true)
-bool(false)
+int(1)
+int(0)
 boolean

--- a/tests/test_boolean.phpt
+++ b/tests/test_boolean.phpt
@@ -15,15 +15,15 @@ if (!$conn) {
 $info = db2_server_info($conn);
 if ($info->DBMS_NAME == "AS") { // IBM i
 	// DBMS_VER is VVRRM string
-	$major = $info["DBMS_VER"][1];
-	$minor = $info["DBMS_VER"][3];
-	$mod = $info["DBMS_VER"][4];
+	$major = $info->DBMS_VER[1];
+	$minor = $info->DBMS_VER[3];
+	$mod = $info->DBMS_VER[4];
 	if (!version_compare("$major.$minor.$mod", "7.5.0", ">=")) {
 		die("skip IBM i version too old");
 	}
 } else { // Should cover i.e. DB2/LINUX
 	// DBMS_VER is VV.RR.MMMM, version_compore should work directly
-	if (!version_compare($info["DBMS_VER"], "9.7.0", ">=")) {
+	if (!version_compare($info->DBMS_VER, "9.7.0", ">=")) {
 		die("skip DB2 version too old");
 	}
 }

--- a/tests/test_boolean.phpt
+++ b/tests/test_boolean.phpt
@@ -36,11 +36,11 @@ if (!$conn) {
 	exit;
 }
 
-$s = db2_exec("values (true, false)");
+$s = db2_exec($conn, "values (true, false)");
 $r = db2_fetch_array($s);
 var_dump($r);
 
-$s = db2_exec("values (true, false)");
+$s = db2_exec($conn, "values (true, false)");
 db2_fetch_row($s);
 var_dump(db2_result($s, 0));
 var_dump(db2_result($s, 1));

--- a/tests/test_boolean.phpt
+++ b/tests/test_boolean.phpt
@@ -5,7 +5,7 @@ IBM-DB2: Boolean data type test.
 
 require_once('skipif.inc');
 
-// This test requires IBM i 7.5 or a version of LUW that supports boolean
+// This test requires IBM i 7.5 or DB2/LUW 9.7 for the boolean type
 require_once('connection.inc');
 $conn = db2_connect($database, $user, $password);
 if (!$conn) {
@@ -15,14 +15,19 @@ if (!$conn) {
 $info = db2_server_info($conn);
 if ($info->DBMS_NAME == "AS") { // IBM i
 	// DBMS_VER is VVRRM string
-	$major = $info[1];
-	$minor = $info[3];
-	$mod = $info[4];
+	$major = $info["DBMS_VER"][1];
+	$minor = $info["DBMS_VER"][3];
+	$mod = $info["DBMS_VER"][4];
 	if (!version_compare("$major.$minor.$mod", "7.5.0", ">=")) {
 		die("skip IBM i version too old");
 	}
+} else { // Should cover i.e. DB2/LINUX
+	// DBMS_VER is VV.RR.MMMM, version_compore should work directly
+	if (!version_compare($info["DBMS_VER"], "9.7.0", ">=")) {
+		die("skip DB2 version too old");
+	}
 }
-// XXX: LUW, z
+// XXX: z
 
 ?>
 --FILE--
@@ -40,6 +45,7 @@ $s = db2_exec($conn, "values (true, false)");
 $r = db2_fetch_array($s);
 var_dump($r);
 
+// db2_result can't return true/false due to API limitations, so these will be ints
 $s = db2_exec($conn, "values (true, false)");
 db2_fetch_row($s);
 var_dump(db2_result($s, 0));


### PR DESCRIPTION
Works with db2_result (albeit returns an integer) and db2_fetch_* (which fetches booleans).

Problems right now:

* [x] CI tests (run it only on supported LUW/i)
* [ ] `db2_bind_param` (untested, figure out story there)

PDO_IBM also should have this, then I need to figure out a way to do this sanely in ODBC.

Fixes GH-56