### PR TITLE
fix: compile on php84

### DIFF
--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -6233,10 +6233,10 @@ static void _php_db2_bind_fetch_helper(INTERNAL_FUNCTION_PARAMETERS, int op)
         loc_length = stmt_res->column_info[i].loc_ind;
         switch(stmt_res->s_case_mode) {
             case DB2_CASE_LOWER:
-                stmt_res->column_info[i].name = (SQLCHAR *)php_strtolower((char *)stmt_res->column_info[i].name, strlen((char *)stmt_res->column_info[i].name));
+                stmt_res->column_info[i].name = (SQLCHAR *)zend_str_tolower_dup((char *)stmt_res->column_info[i].name, strlen((char *)stmt_res->column_info[i].name));
                 break;
             case DB2_CASE_UPPER:
-                stmt_res->column_info[i].name = (SQLCHAR *)php_strtoupper((char *)stmt_res->column_info[i].name, strlen((char *)stmt_res->column_info[i].name));
+                stmt_res->column_info[i].name = (SQLCHAR *)zend_str_toupper_dup((char *)stmt_res->column_info[i].name, strlen((char *)stmt_res->column_info[i].name));
                 break;
             case DB2_CASE_NATURAL:
             default:


### PR DESCRIPTION
The functions `php_strto*` were removed in PHP 8.4.

The replacement functions have been around since PHP 5.4, thus we do not need a conditional macro via define.