### PR TITLE
Fix garbage in column names on IBM i

### DIFF
--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -1971,7 +1971,13 @@ static int _php_db2_get_result_set_info(stmt_handle *stmt_res)
                 return -1;
             }
         } else {
-            stmt_res->column_info[i].name = (SQLCHAR *)estrdup(tmp_name);
+            /*
+             * CB20241114: In some cases on i (i.e. QP2SHELL w/ CCSID 65535),
+             * SQL/CLI might not add a null terminator, and garbage can appear
+             * at the end of column names. However, name_length is still
+             * correct, so we truncate with that when copying the name.
+             */
+            stmt_res->column_info[i].name = (SQLCHAR *)estrndup(tmp_name, name_length);
         }
         switch (stmt_res->column_info[i].type) {
             /* BIGINT 9223372036854775807  (2^63-1) string convert */


### PR DESCRIPTION
A user reported an issue where the column names can have garbage at the end in some situations; in this case, it seems to be using QP2SHELL while also have the CCSID set to 65535. It seems SQL/CLI doesn't null terminate the names when this happens. Arguably a bug in SQL/CLI, and arguably on the user as QP2SHELL requires you to set up the environment yourself, but unfortunately CCSID 65535 and QP2SHELL usage are common.

This resolves the issue by truncating with `name_length`, which is still set correctly.