### PR TITLE
Fix GH-62

### DIFF
--- a/ibm_db2.c
+++ b/ibm_db2.c
@@ -4578,6 +4578,11 @@ static int _php_db2_bind_data( stmt_handle *stmt_res, param_node *curr, zval **b
                     paramValuePtr = (SQLPOINTER)(Z_STRVAL_P(curr->value));
                     break;
                 case SQL_VARCHAR:
+                case SQL_WVARCHAR:
+                case SQL_VARGRAPHIC:
+                case SQL_LONGVARCHAR:
+                case SQL_WLONGVARCHAR:
+                case SQL_LONGVARGRAPHIC:
                     valueType = SQL_C_CHAR;
                     if (origlen != -1) {
                         curr->bind_indicator = origlen;

--- a/tests/test_gh_62.phpt
+++ b/tests/test_gh_62.phpt
@@ -13,11 +13,17 @@ $table = "EMPTY_NVARCHAR";
 $drop = "DROP TABLE $table";
 $res = @db2_exec($conn, $drop);
 /* ensure that SQL_NTS is used so empty strings work for not just VARCHAR */
-$create = "CREATE OR REPLACE TABLE $table (TEXTME NVARCHAR(1024))"; /* CCSID 1200? */
+$create = "CREATE TABLE $table (TEXTME NVARCHAR(1024))"; /* CCSID 1200? */
 $res = db2_exec($conn, $create);
+if ($res == false) {
+	die("Failed to create table: " . db2_stmt_error($create) . " - " . db2_stmt_errormsg($create) . "\n");
+}
 $insert = "INSERT INTO $table (TEXTME) VALUES (?)";
 $sth = db2_prepare($conn, $insert);
 $res = db2_execute($sth, array($input));
+if ($res == false) {
+	die("Failed to insert: " . db2_stmt_error($insert) . " - " . db2_stmt_errormsg($insert) . "\n");
+}
 $look = "select TEXTME from $table";
 $res = db2_exec($conn, $look);
 $row = db2_fetch_array($res);

--- a/tests/test_gh_62.phpt
+++ b/tests/test_gh_62.phpt
@@ -1,0 +1,34 @@
+--TEST--
+IBM-DB2: Binding empty string to NVARCHAR (GH-62)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once('connection.inc');
+
+$conn = db2_connect($database, $user, $password);
+
+$input = '';
+$table = "EMPTY_NVARCHAR";
+$drop = "DROP TABLE $table";
+$res = @db2_exec($conn, $drop);
+/* ensure that SQL_NTS is used so empty strings work for not just VARCHAR */
+$create = "CREATE OR REPLACE TABLE $table (TEXTME NVARCHAR(1024))"; /* CCSID 1200? */
+$res = db2_exec($conn, $create);
+$insert = "INSERT INTO $table (TEXTME) VALUES (?)";
+$sth = db2_prepare($conn, $insert);
+$res = db2_execute($sth, array($input));
+$look = "select TEXTME from $table";
+$res = db2_exec($conn, $look);
+$row = db2_fetch_array($res);
+
+if (bin2hex($row[0]) == bin2hex($input)) {
+	echo "success\n";
+} else {
+	echo "Failure\n";
+}
+
+?>
+--EXPECTF--
+success
+


### PR DESCRIPTION
Other varchar-like types (i.e. nvarchar as wvarchar) need the same treatment so they use SQL_NTS, so that empty strings as the bound parameter will work.